### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,157 +26,157 @@ html, body, #mapdiv {height: 100%; width: 100%;}
 
 //鉄道中心線
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_railcl/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_railcl/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var raillayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_railcl/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_railcl/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //道路中心線
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_rdcl/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_rdcl/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var rdcllayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_rdcl/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_rdcl/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //河川中心線
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_rvrcl/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_rvrcl/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var rvrcllayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_rvrcl/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_rvrcl/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //注記
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_anno/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_anno/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var annolayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_anno/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_anno/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //基盤地図情報_基本項目
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_fgd/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_fgd/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var fgdlayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_fgd/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_fgd/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //基盤地図情報_数値標高モデル（10m）
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_dem10b/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_dem10b/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var dem10blayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_dem10b/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_dem10b/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //基盤地図情報_数値標高モデル（5m）
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_dem5a/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_dem5a/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var dem5alayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_dem5a/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_dem5a/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 //地形分類（自然地形）
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_landformclassification1/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_landformclassification1/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var landformclassification1layer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_landformclassification1/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_landformclassification1/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //地形分類（人工地形）
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_landformclassification2/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_landformclassification2/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var landformclassification2layer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_landformclassification2/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_landformclassification2/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //地名情報（居住地名）
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_nrpt/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_nrpt/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var nrptlayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_nrpt/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_nrpt/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //地名情報（自然地名）
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_nnfpt/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_nnfpt/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var nnfptlayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_nnfpt/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_nnfpt/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //地名情報（公共施設）
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_pfpt/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_pfpt/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var pfptlayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_pfpt/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_pfpt/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 //地名情報（住居表示住所）
 var xhr = new XMLHttpRequest();
-xhr.open('GET', 'http://cyberjapandata.gsi.go.jp/xyz/experimental_jhj/style.js', false);
+xhr.open('GET', 'https://cyberjapandata.gsi.go.jp/xyz/experimental_jhj/style.js', false);
 xhr.send(null);
 var stylejs = eval( "(" + xhr.responseText + ")" );
 
 var jhjlayer = new L.TileLayer.GeoJSON(
-'http://cyberjapandata.gsi.go.jp/xyz/experimental_jhj/{z}/{x}/{y}.geojson',
+'https://cyberjapandata.gsi.go.jp/xyz/experimental_jhj/{z}/{x}/{y}.geojson',
 stylejs.options,stylejs.geojsonOptions);
 
 
 var std = L.tileLayer(
-'http://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png',
+'https://cyberjapandata.gsi.go.jp/xyz/std/{z}/{x}/{y}.png',
 {attribution: "地理院タイル（標準地図）", 
 maxNativeZoom: 18, maxZoom: 18, opacity:1});
 var ort = L.tileLayer(
-'http://cyberjapandata.gsi.go.jp/xyz/ort/{z}/{x}/{y}.jpg',
+'https://cyberjapandata.gsi.go.jp/xyz/ort/{z}/{x}/{y}.jpg',
 {attribution: "地理院タイル（オルソ）", 
 maxNativeZoom: 17, maxZoom: 18, opacity:0.7});
 
 var blank = L.tileLayer(
-'http://cyberjapandata.gsi.go.jp/xyz/blank/{z}/{x}/{y}.png',
+'https://cyberjapandata.gsi.go.jp/xyz/blank/{z}/{x}/{y}.png',
 {attribution: "地理院タイル（白地図）", 
 maxNativeZoom: 14, maxZoom: 18, opacity:1});
 

--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 <title>地理院ベクトルタイル提供実験</title>
-<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css"/>
-<script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@0.7.3/dist/leaflet.css"/>
+<script src="https://unpkg.com/leaflet@0.7.3/dist/leaflet.js"></script>
 <script src="./TileLayer.GeoJSON.js"></script>
 <script src="./leaflet-hash.js"></script>
 <style>


### PR DESCRIPTION
デモサイトが機能していないようなので、動作するようにするためのパッチです。

- GitHub Pages が HTTPS のみ対応になったので、参照される JS/CSS/JSON も HTTPS でないといけない
- Leaflet0.7.3 の取得先が HTTP の cdn.leafletjs.com だったので HTTPS の unpkg.com に変更
- GeoJSON タイルと JSON スタイル定義が HTTP だったので HTTPS に変更
